### PR TITLE
fix order when label text is set

### DIFF
--- a/webapisync.py
+++ b/webapisync.py
@@ -341,8 +341,8 @@ class WebApiSyncTool(BatchTool, ManagedWindow):
     def handle_error(self, message):
         """Handle an error message during sync."""
         self.conclusion.error = True
-        self.conclusion.label.set_text(message)  #
         self.assistant.next_page()
+        self.conclusion.label.set_text(message)  #
         self.conclusion.set_complete()
 
     def handle_unchanged(self):


### PR DESCRIPTION
Change order when the label text is set in conclusion page. This fixes bug #10 